### PR TITLE
Fix keystone develop

### DIFF
--- a/lists/index.js
+++ b/lists/index.js
@@ -3,7 +3,7 @@ const FAQ = require("./faq");
 const Project = require("./project");
 const Users = require("./users");
 const Group = require("./group");
-const projectDetails = require('./projectDetail')
+const ProjectDetails = require('./projectDetail')
 
 const loadLists = (keystone) => {
   Stuff(keystone);
@@ -11,7 +11,7 @@ const loadLists = (keystone) => {
   Project(keystone);
   Users(keystone);
   Group(keystone);
-  projectDetails(keystone)
+  ProjectDetails(keystone)
 };
 
 module.exports = loadLists;

--- a/lists/users.js
+++ b/lists/users.js
@@ -1,7 +1,7 @@
-const { Text } = require("@keystonejs/fields");
+const { Text, Select, Checkbox, Url } = require("@keystonejs/fields");
 
 const Users = (keystone) => {
-    return keystone.createList("users", {
+    return keystone.createList("user", {
         fields: {
             full_name: {
                 type: Text,
@@ -19,6 +19,7 @@ const Users = (keystone) => {
             available_time: {
                 type: Select,
                 options: "2, 4, 6, 8, 10, 12",
+                dataType: "string"
             },
             experience: {
                 type: Checkbox,
@@ -45,7 +46,3 @@ const Users = (keystone) => {
 };
 
 module.exports = Users;
-
-// Documentation on field types :
-// https://www.keystonejs.com/blog/field-types
-// https://www.keystonejs.com/keystonejs/fields/#fields

--- a/migrations/20201213200905_create_users.js
+++ b/migrations/20201213200905_create_users.js
@@ -1,5 +1,5 @@
 exports.up = function (knex) {
-    return knex.schema.createTable("users", function (table) {
+    return knex.schema.createTable("user", function (table) {
         table.increments("id").primary();
         // I'm not sure if this is the right way of adding FK but I leave them here just in case:
 


### PR DESCRIPTION
## Description 

I found some problems after merge all the branches to develop and I fixed them:

* The user table migration was defined with a plural name but that's incorrect for knex. We should use singular names.
* On the user list, I needed to import `Select`, `Checkbox`, and `Url` field types.
* On the user list, I fixed the `available_time` field because when the select value needs to be integer for example, like in this case, we should specify the `dataType` as `string` because `enum` is the default `dataType` for select fields has a lot of restrictions on possible values.